### PR TITLE
AppImage: native Wayland (v0.1.2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           version: '6.7.2'
-          modules: 'qtmultimedia qtshadertools'
+          modules: 'qtmultimedia qtshadertools qtwayland'
       - name: System deps
         run: |
           sudo apt-get update
@@ -37,6 +37,11 @@ jobs:
           NO_STRIP: '1'
           QML_SOURCES_PATHS: ${{ github.workspace }}/src/ui/qml
           OUTPUT: reolink-native-linux-x86_64.AppImage
+          # Bundle Qt's Wayland platform plugins too (the qt plugin ships only the
+          # "best" platform = xcb by default). With qtwayland installed, linuxdeploy
+          # also pulls in the wayland-shell-integration / decoration plugins, so the
+          # app runs natively on Wayland instead of falling back to XWayland.
+          EXTRA_PLATFORM_PLUGINS: 'libqwayland-egl.so;libqwayland-generic.so'
         run: |
           # The qt plugin locates Qt via $QMAKE — without it, it finds no
           # modules ("Could not find Qt modules to deploy").

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(reolink-client
-    VERSION 0.1.1
+    VERSION 0.1.2
     DESCRIPTION "Native Linux client for Reolink cameras and NVRs"
     LANGUAGES CXX)
 

--- a/packaging/io.github.todesengelx.ReolinkLinux.metainfo.xml
+++ b/packaging/io.github.todesengelx.ReolinkLinux.metainfo.xml
@@ -27,6 +27,9 @@
     <category>Video</category>
   </categories>
   <releases>
+    <release version="0.1.2" date="2026-07-30">
+      <description><p>The AppImage now runs natively on Wayland (bundles the Qt Wayland platform plugins) instead of falling back to XWayland.</p></description>
+    </release>
     <release version="0.1.1" date="2026-07-12">
       <description><p>Detection-zone editor, 6-camera live grid, desktop notifications, a nested device tree with icons, event retention cap, and a built-in update checker.</p></description>
     </release>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,7 @@ int main(int argc, char *argv[])
     QGuiApplication app(argc, argv);
     QCoreApplication::setOrganizationName(QStringLiteral("reolink-linux"));
     QCoreApplication::setApplicationName(QStringLiteral("reolink-client"));
-    QCoreApplication::setApplicationVersion(QStringLiteral("0.1.1"));
+    QCoreApplication::setApplicationVersion(QStringLiteral("0.1.2"));
 
     // Give the app a real identity in the taskbar/dock. setDesktopFileName lets
     // Wayland compositors match the window to the installed .desktop file and


### PR DESCRIPTION
Bundle Qt's Wayland platform plugins in the AppImage so it runs natively on Wayland instead of XWayland. Packaging + version bump only.